### PR TITLE
feat: use dev baseline tags for change detection instead of release tags

### DIFF
--- a/packages/lazy-wheels/lazy_wheels/templates/release-matrix.yml
+++ b/packages/lazy-wheels/lazy_wheels/templates/release-matrix.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       changed: ${{ steps.discover.outputs.changed }}
       unchanged: ${{ steps.discover.outputs.unchanged }}
-      last_tags: ${{ steps.discover.outputs.last_tags }}
+      release_tags: ${{ steps.discover.outputs.release_tags }}
       release: ${{ steps.discover.outputs.release }}
     steps:
       - uses: actions/checkout@v4
@@ -98,7 +98,7 @@ __MATRIX_INCLUDE__
       - name: Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python -m lazy_wheels.workflow_steps release --changed '${{ needs.discover.outputs.changed }}' --unchanged '${{ needs.discover.outputs.unchanged }}' --last-tags '${{ needs.discover.outputs.last_tags }}' --release-tag '${{ needs.discover.outputs.release }}'
+        run: python -m lazy_wheels.workflow_steps release --changed '${{ needs.discover.outputs.changed }}' --unchanged '${{ needs.discover.outputs.unchanged }}' --release-tags '${{ needs.discover.outputs.release_tags }}' --release-tag '${{ needs.discover.outputs.release }}'
       - name: Push commits and tags
         run: |
           git push

--- a/packages/lazy-wheels/tests/test_workflow_steps.py
+++ b/packages/lazy-wheels/tests/test_workflow_steps.py
@@ -13,22 +13,28 @@ from lazy_wheels.workflow_steps import build, discover, main
 
 
 @patch("lazy_wheels.workflow_steps.find_next_release_tag")
-@patch("lazy_wheels.workflow_steps.find_last_tags")
+@patch("lazy_wheels.workflow_steps.find_dev_baselines")
+@patch("lazy_wheels.workflow_steps.find_release_tags")
 @patch("lazy_wheels.workflow_steps.detect_changes")
 @patch("lazy_wheels.workflow_steps.discover_packages")
 def test_discover_writes_expected_outputs(
     mock_discover: MagicMock,
     mock_detect: MagicMock,
-    mock_find_last: MagicMock,
+    mock_find_release: MagicMock,
+    mock_find_dev: MagicMock,
     mock_find_next: MagicMock,
     tmp_path: Path,
 ) -> None:
-    """discover writes changed/unchanged/last_tags/release to output file."""
+    """discover writes changed/unchanged/release_tags/release to output file."""
     mock_discover.return_value = {
         "pkg-a": PackageInfo(path="packages/a", version="1.0.0", deps=[]),
         "pkg-b": PackageInfo(path="packages/b", version="1.0.0", deps=[]),
     }
-    mock_find_last.return_value = {"pkg-a": "pkg-a/v1.0.0", "pkg-b": "pkg-b/v1.0.0"}
+    mock_find_release.return_value = {"pkg-a": "pkg-a/v1.0.0", "pkg-b": "pkg-b/v1.0.0"}
+    mock_find_dev.return_value = {
+        "pkg-a": "pkg-a/v1.0.0-dev",
+        "pkg-b": "pkg-b/v1.0.0-dev",
+    }
     mock_detect.return_value = ["pkg-a"]
     mock_find_next.return_value = "r7"
     output_file = tmp_path / "github_output.txt"
@@ -38,7 +44,7 @@ def test_discover_writes_expected_outputs(
     raw = output_file.read_text()
     assert 'changed=["pkg-a"]' in raw
     assert 'unchanged=["pkg-b"]' in raw
-    assert 'last_tags={"pkg-a": "pkg-a/v1.0.0", "pkg-b": "pkg-b/v1.0.0"}' in raw
+    assert 'release_tags={"pkg-a": "pkg-a/v1.0.0", "pkg-b": "pkg-b/v1.0.0"}' in raw
     assert "release=r7" in raw
 
 


### PR DESCRIPTION
Introduces a two-tag system: release tags ({pkg}/v{version}) for fetching previous wheels, and dev baseline tags ({pkg}/v{version}-dev) for diffing changes. The dev baseline is placed on the version bump commit after each release, so only real work shows up in the diff. This eliminates the need for the _is_only_version_bump heuristic.

https://claude.ai/code/session_019P6biY6QGo9XdVjHQqHtos