### PR TITLE
Add pyyaml as runtime dependency

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix `ModuleNotFoundError: No module named 'yaml'` on every `uvr` invocation by declaring `pyyaml` as a runtime dependency (#20)
+
 ## [v0.22.0] - 2026-04-02
 
 ### Added

--- a/packages/uv-release/pyproject.toml
+++ b/packages/uv-release/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "packaging>=23.0",
     "pydantic>=2.0",
     "pygit2>=1.19.1",
+    "pyyaml>=6.0",
     "tomlkit>=0.12",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -806,6 +806,7 @@ dependencies = [
     { name = "packaging" },
     { name = "pydantic" },
     { name = "pygit2" },
+    { name = "pyyaml" },
     { name = "tomlkit" },
 ]
 
@@ -819,6 +820,7 @@ requires-dist = [
     { name = "packaging", specifier = ">=23.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pygit2", specifier = ">=1.19.1" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "tomlkit", specifier = ">=0.12" },
 ]
 


### PR DESCRIPTION
## Summary
This PR fixes a `ModuleNotFoundError` that occurs when invoking the `uvr` command by declaring `pyyaml` as an explicit runtime dependency.

## Changes
- Added `pyyaml>=6.0` to the runtime dependencies in `pyproject.toml`
- Updated `CHANGELOG.md` to document the fix

## Details
The `pyyaml` package was being used by the application but was not declared as a direct dependency, causing import failures at runtime. This change ensures `pyyaml` is properly installed when the package is installed, resolving the `ModuleNotFoundError: No module named 'yaml'` error.

https://claude.ai/code/session_01Wo7P5AUcb7JcEYbHPDfeJx