### PR TITLE
fix: resolve --skip-to from workflow DAG instead of hardcoded job list

### DIFF
--- a/packages/uv-release/tests/integration/test_cli_commands.py
+++ b/packages/uv-release/tests/integration/test_cli_commands.py
@@ -24,6 +24,42 @@ def _ns(**kwargs: object) -> argparse.Namespace:
     return argparse.Namespace(**kwargs)
 
 
+def _write_workflow_with_checks(workspace: Path) -> None:
+    """Write a release.yml that has a custom 'checks' job before build and commit it."""
+    workflow_dir = workspace / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True, exist_ok=True)
+    (workflow_dir / "release.yml").write_text(
+        "name: Release\n"
+        "on: workflow_dispatch\n"
+        "jobs:\n"
+        "  validate:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps: []\n"
+        "  checks:\n"
+        "    needs: [validate]\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps: []\n"
+        "  build:\n"
+        "    needs: [validate, checks]\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps: []\n"
+        "  release:\n"
+        "    needs: [build]\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps: []\n"
+        "  publish:\n"
+        "    needs: [release]\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps: []\n"
+        "  bump:\n"
+        "    needs: [publish]\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps: []\n"
+    )
+    _git(workspace, "add", "-A")
+    _git(workspace, "commit", "-m", "add release workflow")
+
+
 def _release_ns(**overrides: object) -> argparse.Namespace:
     """Build a release Namespace with sensible defaults."""
     defaults: dict[str, object] = {
@@ -187,6 +223,28 @@ class TestCmdRelease:
         assert "Pipeline" in out
 
     def test_skip_to_unknown_job_exits(self, workspace: Path) -> None:
+        with pytest.raises(SystemExit):
+            cmd_release(_release_ns(skip_to="nonexistent-job"))
+
+    def test_skip_to_with_custom_workflow_job(
+        self, workspace: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_workflow_with_checks(workspace)
+        cmd_release(_release_ns(skip_to="build", json_output=True, dry_run=False))
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert "checks" in parsed["skip"]
+
+    def test_skip_to_targets_custom_job(
+        self, workspace: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        _write_workflow_with_checks(workspace)
+        cmd_release(_release_ns(skip_to="checks"))
+        out = capsys.readouterr().out
+        assert "Pipeline" in out
+
+    def test_skip_to_unknown_job_exits_with_workflow(self, workspace: Path) -> None:
+        _write_workflow_with_checks(workspace)
         with pytest.raises(SystemExit):
             cmd_release(_release_ns(skip_to="nonexistent-job"))
 

--- a/packages/uv-release/tests/unit/test_graph.py
+++ b/packages/uv-release/tests/unit/test_graph.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from uv_release.utils.graph import topo_layers, topo_sort
+from uv_release.utils.graph import compute_ancestors, topo_layers, topo_sort
 from uv_release.types import Package, Version
 
 
@@ -80,3 +80,56 @@ class TestTopoSort:
     def test_cycle_raises(self) -> None:
         with pytest.raises(RuntimeError, match="cycle"):
             topo_sort({"a": ["b"], "b": ["a"]})
+
+
+class TestComputeAncestors:
+    """Tests for compute_ancestors (strict ancestor set via BFS)."""
+
+    def test_linear_chain(self) -> None:
+        dag = {
+            "validate": [],
+            "build": ["validate"],
+            "release": ["build"],
+            "publish": ["release"],
+            "bump": ["publish"],
+        }
+        assert compute_ancestors(dag, "release") == {"validate", "build"}
+
+    def test_custom_job_in_chain(self) -> None:
+        dag = {
+            "validate": [],
+            "checks": ["validate"],
+            "build": ["validate", "checks"],
+            "release": ["build"],
+        }
+        assert compute_ancestors(dag, "build") == {"validate", "checks"}
+
+    def test_root_node_has_no_ancestors(self) -> None:
+        dag = {"validate": [], "build": ["validate"]}
+        assert compute_ancestors(dag, "validate") == set()
+
+    def test_target_not_in_dag_raises(self) -> None:
+        dag = {"validate": [], "build": ["validate"]}
+        with pytest.raises(KeyError):
+            compute_ancestors(dag, "nonexistent")
+
+    def test_diamond_dag(self) -> None:
+        dag = {
+            "validate": [],
+            "build": ["validate"],
+            "scan": ["validate"],
+            "release": ["build", "scan"],
+        }
+        assert compute_ancestors(dag, "release") == {"validate", "build", "scan"}
+
+    def test_parallel_branch_not_included(self) -> None:
+        """A job on a parallel branch is not an ancestor of the target."""
+        dag = {
+            "validate": [],
+            "build": ["validate"],
+            "scan": ["build"],
+            "release": ["build"],
+            "publish": ["release"],
+        }
+        assert compute_ancestors(dag, "release") == {"validate", "build"}
+        assert "scan" not in compute_ancestors(dag, "release")

--- a/packages/uv-release/uv_release/cli/release.py
+++ b/packages/uv-release/uv_release/cli/release.py
@@ -58,21 +58,10 @@ def cmd_release(args: argparse.Namespace) -> None:
     # Compute skip set from --skip and --skip-to
     skipped = set(parsed.skip or [])
     if parsed.skip_to:
-        _JOB_ORDER = [
-            "validate",
-            "build",
-            "release",
-            "publish",
-            "bump",
-        ]
-        if parsed.skip_to not in _JOB_ORDER:
-            print(
-                f"ERROR: Unknown job '{parsed.skip_to}' for --skip-to.",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        idx = _JOB_ORDER.index(parsed.skip_to)
-        skipped |= {j for j in _JOB_ORDER[:idx] if j != "validate"}
+        skipped |= _resolve_skip_to(
+            parsed.skip_to,
+            Path.cwd() / ".github/workflows/release.yml",
+        )
 
     params = PlanParams(
         all_packages=parsed.all_packages,
@@ -102,6 +91,12 @@ def cmd_release(args: argparse.Namespace) -> None:
     except ValueError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         sys.exit(1)
+
+    # Merge skipped custom CI jobs into plan.skip so the workflow
+    # ``if: !contains(...)`` condition can gate them.
+    extra_skip = skipped - {j.name for j in plan.jobs} - {"validate"}
+    if extra_skip and plan.jobs:
+        plan = plan.model_copy(update={"skip": sorted(set(plan.skip) | extra_skip)})
 
     if not plan.jobs:
         if parsed.json_output:
@@ -173,6 +168,67 @@ def _parse_release_notes(raw: list[list[str]] | None) -> dict[str, str]:
         else:
             result[pkg_name] = notes_value
     return result
+
+
+_DEFAULT_JOB_ORDER = ["validate", "build", "release", "publish", "bump"]
+
+
+def _read_workflow_job_dag(workflow_path: Path) -> dict[str, list[str]]:
+    """Parse ``release.yml`` into a job dependency DAG.
+
+    Returns a mapping of ``{job_name: [dependency_names]}`` derived from the
+    ``needs:`` field of each job. Returns an empty dict when the file is
+    missing or cannot be parsed.
+    """
+    if not workflow_path.exists():
+        return {}
+    try:
+        import yaml
+
+        content = yaml.safe_load(workflow_path.read_text())
+    except Exception:
+        return {}
+    if not content or "jobs" not in content:
+        return {}
+
+    dag: dict[str, list[str]] = {}
+    for name, config in content["jobs"].items():
+        needs = config.get("needs", [])
+        if isinstance(needs, str):
+            needs = [needs]
+        dag[name] = needs
+    return dag
+
+
+def _resolve_skip_to(skip_to: str, workflow_path: Path) -> set[str]:
+    """Resolve ``--skip-to`` into a set of job names to skip.
+
+    Reads the workflow YAML, builds the job dependency DAG, and returns all
+    ancestors of *skip_to* (except ``validate``). Falls back to the default
+    linear order when no workflow file is available.
+    """
+    dag = _read_workflow_job_dag(workflow_path)
+
+    if dag:
+        if skip_to not in dag:
+            print(
+                f"ERROR: Unknown job '{skip_to}' for --skip-to.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        from ..utils.graph import compute_ancestors
+
+        return compute_ancestors(dag, skip_to) - {"validate"}
+
+    # Fallback: no workflow file, use default linear order
+    if skip_to not in _DEFAULT_JOB_ORDER:
+        print(
+            f"ERROR: Unknown job '{skip_to}' for --skip-to.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    idx = _DEFAULT_JOB_ORDER.index(skip_to)
+    return {j for j in _DEFAULT_JOB_ORDER[:idx] if j != "validate"}
 
 
 def _dispatch_to_ci(plan: Plan) -> None:

--- a/packages/uv-release/uv_release/utils/graph.py
+++ b/packages/uv-release/uv_release/utils/graph.py
@@ -86,3 +86,29 @@ def topo_layers(packages: dict[str, Package]) -> dict[str, int]:
         raise RuntimeError(msg)
 
     return layers
+
+
+def compute_ancestors(dag: dict[str, list[str]], target: str) -> set[str]:
+    """Return the set of strict ancestors of *target* in a dependency DAG.
+
+    An ancestor is any node reachable by walking backward through
+    dependency (``needs``) edges. *target* itself is not included.
+
+    Args:
+        dag: mapping of node name to its dependencies (names it depends ON).
+        target: the node whose ancestors to compute.
+
+    Raises:
+        KeyError: if *target* is not a key in *dag*.
+    """
+    if target not in dag:
+        raise KeyError(target)
+
+    ancestors: set[str] = set()
+    queue = list(dag[target])
+    while queue:
+        node = queue.pop(0)
+        if node not in ancestors and node in dag:
+            ancestors.add(node)
+            queue.extend(dag[node])
+    return ancestors


### PR DESCRIPTION
## Summary

- `--skip-to` used a hardcoded `_JOB_ORDER` list that only knew the five standard jobs (validate, build, release, publish, bump). Workflows with custom jobs between them were not handled correctly.
- Now reads the actual `release.yml`, builds the `needs:` DAG, and computes ancestors of the target job via BFS. Falls back to the default linear order when no workflow file exists.
- Custom CI-only job names are merged into `plan.skip` after plan construction so the workflow `if: !contains(...)` condition gates them properly.
- Parallel branches in the DAG are correctly excluded from the skip set (only true ancestors of the target are skipped).

## Test plan

- [x] All 541 existing tests pass
- [x] New unit tests for `compute_ancestors` (linear chain, custom job, root node, missing target, diamond, parallel branch)
- [x] New integration tests for `--skip-to` with custom workflow jobs, targeting custom jobs, and unknown jobs with workflow file present

🤖 Generated with [Claude Code](https://claude.com/claude-code)